### PR TITLE
Example PR of fixing thread pool of AWS glue client.

### DIFF
--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultAWSGlueMetastore.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultAWSGlueMetastore.java
@@ -57,7 +57,6 @@ import com.amazonaws.services.glue.model.UserDefinedFunction;
 import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -73,7 +72,6 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -110,14 +108,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
      */
     public static final String SKIP_AWS_GLUE_ARCHIVE = "skipAWSGlueArchive";
 
-    private static final int NUM_EXECUTOR_THREADS = 5;
     static final String GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT = "glue-metastore-delegate-%d";
-    private static final ExecutorService GLUE_METASTORE_DELEGATE_THREAD_POOL = Executors.newFixedThreadPool(
-            NUM_EXECUTOR_THREADS,
-            new ThreadFactoryBuilder()
-                    .setNameFormat(GLUE_METASTORE_DELEGATE_THREADPOOL_NAME_FORMAT)
-                    .setDaemon(true).build()
-    );
 
     private final Configuration conf;
     private final AWSGlue glueClient;
@@ -508,7 +499,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
                         .withTableName(tableName)
                         .withPartitionValues(partValues)
                         .withColumnNames(cols);
-                pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<GetColumnStatisticsForPartitionResult>() {
+                pagedResult.add(this.executorService.submit(new Callable<GetColumnStatisticsForPartitionResult>() {
                     @Override
                     public GetColumnStatisticsForPartitionResult call() throws Exception {
                         return glueClient.getColumnStatisticsForPartition(request);
@@ -543,7 +534,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
                     .withDatabaseName(dbName)
                     .withTableName(tableName)
                     .withColumnNames(cols);
-            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<GetColumnStatisticsForTableResult>() {
+            pagedResult.add(this.executorService.submit(new Callable<GetColumnStatisticsForTableResult>() {
                 @Override
                 public GetColumnStatisticsForTableResult call() throws Exception {
                     return glueClient.getColumnStatisticsForTable(request);
@@ -581,7 +572,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
                     .withTableName(tableName)
                     .withPartitionValues(partitionValues)
                     .withColumnStatisticsList(statList);
-            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<UpdateColumnStatisticsForPartitionResult>() {
+            pagedResult.add(this.executorService.submit(new Callable<UpdateColumnStatisticsForPartitionResult>() {
                 @Override
                 public UpdateColumnStatisticsForPartitionResult call() throws Exception {
                     return glueClient.updateColumnStatisticsForPartition(request);
@@ -617,7 +608,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
                     .withDatabaseName(dbName)
                     .withTableName(tableName)
                     .withColumnStatisticsList(statList);
-            pagedResult.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<UpdateColumnStatisticsForTableResult>() {
+            pagedResult.add(this.executorService.submit(new Callable<UpdateColumnStatisticsForTableResult>() {
                 @Override
                 public UpdateColumnStatisticsForTableResult call() throws Exception {
                     return glueClient.updateColumnStatisticsForTable(request);

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
@@ -7,6 +7,7 @@ import com.amazonaws.glue.catalog.converters.CatalogToHiveConverterFactory;
 import com.amazonaws.glue.catalog.converters.GlueInputConverter;
 import com.amazonaws.glue.catalog.converters.HiveToCatalogConverter;
 import com.amazonaws.glue.catalog.util.TestObjects;
+import com.amazonaws.glue.catalog.util.TestExecutorServiceFactory;
 import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.model.AlreadyExistsException;
 import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
@@ -173,6 +174,21 @@ public class GlueMetastoreClientDelegateTest {
     when(wh.getDnsPath(path)).thenReturn(path);
     when(wh.isDir(path)).thenReturn(isDir);
     when(wh.mkdirs(path)).thenReturn(mkDir);
+  }
+
+  // ===================== Thread Executor =====================
+
+  @Test
+  public void testExecutorService() throws Exception {
+    Object defaultExecutorService = new DefaultExecutorServiceFactory().getExecutorService(conf);
+    assertEquals("Default executor service should be used", metastoreClientDelegate.getExecutorService(), defaultExecutorService);
+    HiveConf customConf = new HiveConf();
+    customConf.set(GlueMetastoreClientDelegate.CATALOG_ID_CONF, CATALOG_ID);
+    customConf.setClass(GlueMetastoreClientDelegate.CUSTOM_EXECUTOR_FACTORY_CONF, TestExecutorServiceFactory.class, ExecutorServiceFactory.class);
+    GlueMetastoreClientDelegate customDelegate = new GlueMetastoreClientDelegate(customConf, mock(AWSGlue.class), mock(Warehouse.class));
+    Object customExecutorService = new TestExecutorServiceFactory().getExecutorService(customConf);
+
+    assertEquals("Custom executor service should be used", customDelegate.getExecutorService(), customExecutorService);
   }
 
   // ===================== Database =====================

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegateTest.java
@@ -182,6 +182,7 @@ public class GlueMetastoreClientDelegateTest {
   public void testExecutorService() throws Exception {
     Object defaultExecutorService = new DefaultExecutorServiceFactory().getExecutorService(conf);
     assertEquals("Default executor service should be used", metastoreClientDelegate.getExecutorService(), defaultExecutorService);
+    assertEquals("Default executor service should be used", (new DefaultAWSGlueMetastore(conf, glueClient)).getExecutorService(), defaultExecutorService);
     HiveConf customConf = new HiveConf();
     customConf.set(GlueMetastoreClientDelegate.CATALOG_ID_CONF, CATALOG_ID);
     customConf.setClass(GlueMetastoreClientDelegate.CUSTOM_EXECUTOR_FACTORY_CONF, TestExecutorServiceFactory.class, ExecutorServiceFactory.class);
@@ -189,6 +190,7 @@ public class GlueMetastoreClientDelegateTest {
     Object customExecutorService = new TestExecutorServiceFactory().getExecutorService(customConf);
 
     assertEquals("Custom executor service should be used", customDelegate.getExecutorService(), customExecutorService);
+    assertEquals("Default executor service should be used", (new DefaultAWSGlueMetastore(customConf, glueClient)).getExecutorService(), customExecutorService);
   }
 
   // ===================== Database =====================

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/TestExecutorService.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/TestExecutorService.java
@@ -1,0 +1,11 @@
+package com.amazonaws.glue.catalog.util;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+
+public class TestExecutorService extends ScheduledThreadPoolExecutor {
+
+    public TestExecutorService(int corePoolSize, ThreadFactory factory) {
+        super(corePoolSize, factory);
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/TestExecutorServiceFactory.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/util/TestExecutorServiceFactory.java
@@ -1,0 +1,16 @@
+package com.amazonaws.glue.catalog.util;
+
+import com.amazonaws.glue.catalog.metastore.ExecutorServiceFactory;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+import java.util.concurrent.ExecutorService;
+
+public class TestExecutorServiceFactory implements ExecutorServiceFactory {
+    private static ExecutorService execService = new TestExecutorService(1, new ThreadFactoryBuilder().build());
+
+    @Override
+    public ExecutorService getExecutorService(HiveConf conf) {
+        return execService;
+    }
+}

--- a/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-spark-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -112,7 +112,6 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
   // TODO "hook" into Hive logging (hive or hive.metastore)
   private static final Logger logger = Logger.getLogger(AWSCatalogMetastoreClient.class);
 
-  private final ExecutorService executorService;
   private final HiveConf conf;
   private final AWSGlue glueClient;
   private final Warehouse wh;


### PR DESCRIPTION
This is my internal Databricks PR fixing the AWS glue client to use our thread pool.

This was supposed to re-cherry pick #11, which is dropped by https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/commit/5e1546bfa68835cd5a642a9d78ecf39f79554802. (which is picked up Databricks in this https://github.com/databricks/universe/pull/290985)

However, while I am cherry picking, I found out more thread pools are being used in AWSglue client. So second commit of this PR, I am fixing those as well.

I haven't add tests for those new code I made.